### PR TITLE
Fix capitalisation of README.md

### DIFF
--- a/docs/gemstash-private-gems.7.md
+++ b/docs/gemstash-private-gems.7.md
@@ -5,7 +5,7 @@
 
 Stashing private gems in your Gemstash server requires a bit of
 additional setup. If you haven’t read through the [Quickstart
-Guide](../readme.md#quickstart-guide), you should do that first. By the
+Guide](../README.md#quickstart-guide), you should do that first. By the
 end of this guide, you will be able to interact with your Gemstash
 server to store and retrieve your private gems.
 


### PR DESCRIPTION
# Description:

Fix the capitalisation of `README.md` for the link to the quick-start guide. When viewing the page on Github the link is broken as it is case sensitive.